### PR TITLE
Adjusting minimum dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ before_script:
   - if [[ $TRAVIS_PHP_VERSION -lt '7.0' && $TRAVIS_PHP_VERSION != 'hhv*' ]]; then phpenv config-rm xdebug.ini; fi
   - composer self-update
   - composer install --prefer-source
+  - if [ "$DEPENDENCIES" != "low" ]; then composer update; fi;
+  - if [ "$DEPENDENCIES" == "low" ]; then composer update --prefer-lowest; fi;
 
 script:
   - ENABLE_SECOND_LEVEL_CACHE=0 ./vendor/bin/phpunit -v -c tests/travis/$DB.travis.xml $PHPUNIT_FLAGS
@@ -37,6 +39,10 @@ matrix:
       env: DB=mariadb
       addons:
         mariadb: 10.1
+    - php: 7.1
+      env:
+        - DB=sqlite
+        - DEPENDENCIES='low'
     - php: hhvm
       sudo: true
       dist: trusty

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": "^7.0",
         "ext-pdo": "*",
-        "doctrine/collections": "~1.2",
+        "doctrine/collections": "~1.3",
         "doctrine/dbal": ">=2.5-dev,<2.7-dev",
         "doctrine/instantiator": "~1.0.1",
         "doctrine/common": "^2.7.1",

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "doctrine/instantiator": "~1.0.1",
         "doctrine/common": "^2.7.1",
         "doctrine/cache": "~1.5",
+        "doctrine/annotations": "~1.2",
         "symfony/console": "~2.5|~3.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "doctrine/dbal": ">=2.5-dev,<2.7-dev",
         "doctrine/instantiator": "~1.0.1",
         "doctrine/common": "^2.7.1",
-        "doctrine/cache": "~1.4",
+        "doctrine/cache": "~1.5",
         "symfony/console": "~2.5|~3.0"
     },
     "require-dev": {


### PR DESCRIPTION
Keeping a `composer.json` file as accurate as possible is important, to ensure users end up with working combinations of dependencies.

There are lots of PHP projects (e.g. [1](https://github.com/sebastianbergmann/phpunit/blob/f744295e62bf37531eba83a6759f18eacac43acd/.travis.yml#L23) [2](https://github.com/symfony/symfony/blob/4d6ef9eac708dee0c90025a52d91bf89f45ea085/.travis.yml#L102) [3](https://github.com/phpspec/phpspec/blob/ac188150bd8f7bf3789254d8f66418a3fc1dc736/.travis.yml#L30) [4](https://github.com/phpspec/prophecy/blob/abe41cb27f4e4207c6f54a09272969fe55e0bbff/.travis.yml#L35)) where Composer is run with the `--prefer-lowest` flag, to get the minimum versions of dependencies allowed by the `composer.json` file, as part of a special build.  This ensures that the dependency ranges given will work.

This PR adds such a build to Doctrine, and corrects the minimum dependencies specified in `composer.json`, to get the tests to pass.